### PR TITLE
Fix react app header text overflowing out of header box

### DIFF
--- a/node-webservice/react-client/src/App.css
+++ b/node-webservice/react-client/src/App.css
@@ -14,7 +14,6 @@
   width: 100vw;
   display: flex;
   justify-content: center;
-  height: calc(30px + 6vmin);
   font-size: calc(10px + 2vmin);
   color: white;
 }


### PR DESCRIPTION
Open the react app and make the window narrow. The text in the header shouldnt overflow out of the header area