### PR TITLE
made text inputs all-caps.

### DIFF
--- a/node-webservice/react-client/src/Components/TextInput.jsx
+++ b/node-webservice/react-client/src/Components/TextInput.jsx
@@ -25,7 +25,7 @@ class TextInput extends Component {
     }
 
     handleChange(event){
-        this.setState({value: event.target.value})
+        this.setState({value: event.target.value.toUpperCase()})
     }
 
     handleSubmit(event){


### PR DESCRIPTION
Now TextInput fields will be in all-caps.

Test from the game-joining page http://localhost:3000/ 

Text written in the field will display as uppercase regardless of input case.  

Shea, I set you as the reviewer because Github says you've edited this file recently.  
Possible unintended side effect may be that nicknames will be in all-caps, if that field (when implemented) uses the TextInput base. 