### PR TITLE
Clean up compiler warnings and unused meta files from Unity project

### DIFF
--- a/BotRoyaleUnity/Assets/Scripts/CountDown.cs
+++ b/BotRoyaleUnity/Assets/Scripts/CountDown.cs
@@ -6,11 +6,11 @@ using TMPro;
 
 public class CountDown : MonoBehaviour
 {
-    [SerializeField] private List<GameObject> ObjectList;
-    [SerializeField] private GameStateManager.GameStates StateOn;
-    [SerializeField] private GameStateManager.GameStates StateOff;
+    [SerializeField] private List<GameObject> ObjectList = default;
+    [SerializeField] private GameStateManager.GameStates StateOn = GameStateManager.GameStates.NONE;
+    [SerializeField] private GameStateManager.GameStates StateOff = GameStateManager.GameStates.NONE;
 
-    [SerializeField] private TextMeshPro time;
+    [SerializeField] private TextMeshPro time = default;
     [SerializeField] private float BuildTime = 0.0f;
     private bool timeUp = true;
 

--- a/BotRoyaleUnity/Assets/Scripts/OrbitCamera.cs
+++ b/BotRoyaleUnity/Assets/Scripts/OrbitCamera.cs
@@ -4,7 +4,7 @@ using UnityEngine;
 
 public class OrbitCamera : MonoBehaviour
 {
-    [SerializeField] private float speed;
+    [SerializeField] private float speed = 1f;
 
     void Update()
     {

--- a/BotRoyaleUnity/Assets/Scripts/RobotList.cs
+++ b/BotRoyaleUnity/Assets/Scripts/RobotList.cs
@@ -4,7 +4,7 @@ using UnityEngine;
 
 public class RobotList : MonoBehaviour
 {
-    [SerializeField] private Cinemachine.CinemachineTargetGroup cinemachine;
+    [SerializeField] private Cinemachine.CinemachineTargetGroup cinemachine = default;
     private List<Cinemachine.CinemachineTargetGroup.Target> targets = new List<Cinemachine.CinemachineTargetGroup.Target>();
     // private GameObject[] robotObject = null;
     // private List<Transform> robots = new List<Transform>();

--- a/BotRoyaleUnity/Assets/TextMesh Pro/Examples & Extras/Fonts.meta
+++ b/BotRoyaleUnity/Assets/TextMesh Pro/Examples & Extras/Fonts.meta
@@ -1,8 +1,0 @@
-fileFormatVersion: 2
-guid: b63e0053080646b9819789bf3bf9fa17
-folderAsset: yes
-DefaultImporter:
-  externalObjects: {}
-  userData: 
-  assetBundleName: 
-  assetBundleVariant: 

--- a/BotRoyaleUnity/Assets/TextMesh Pro/Examples & Extras/Materials.meta
+++ b/BotRoyaleUnity/Assets/TextMesh Pro/Examples & Extras/Materials.meta
@@ -1,8 +1,0 @@
-fileFormatVersion: 2
-guid: 5808953df7a24274a851aa6dee52d30e
-folderAsset: yes
-DefaultImporter:
-  externalObjects: {}
-  userData: 
-  assetBundleName: 
-  assetBundleVariant: 

--- a/BotRoyaleUnity/Assets/TextMesh Pro/Examples & Extras/Prefabs.meta
+++ b/BotRoyaleUnity/Assets/TextMesh Pro/Examples & Extras/Prefabs.meta
@@ -1,8 +1,0 @@
-fileFormatVersion: 2
-guid: 5bff2544887143f5807c7d5059d07f79
-folderAsset: yes
-DefaultImporter:
-  externalObjects: {}
-  userData: 
-  assetBundleName: 
-  assetBundleVariant: 

--- a/BotRoyaleUnity/Assets/TextMesh Pro/Examples & Extras/Resources.meta
+++ b/BotRoyaleUnity/Assets/TextMesh Pro/Examples & Extras/Resources.meta
@@ -1,8 +1,0 @@
-fileFormatVersion: 2
-guid: d6d3a169ad794942a21da6a552d62f6f
-folderAsset: yes
-DefaultImporter:
-  externalObjects: {}
-  userData: 
-  assetBundleName: 
-  assetBundleVariant: 

--- a/BotRoyaleUnity/Assets/TextMesh Pro/Examples & Extras/Resources/Color Gradient Presets.meta
+++ b/BotRoyaleUnity/Assets/TextMesh Pro/Examples & Extras/Resources/Color Gradient Presets.meta
@@ -1,8 +1,0 @@
-fileFormatVersion: 2
-guid: 7f422cd1388b01047a58cd07c7a23d9d
-folderAsset: yes
-DefaultImporter:
-  externalObjects: {}
-  userData: 
-  assetBundleName: 
-  assetBundleVariant: 

--- a/BotRoyaleUnity/Assets/TextMesh Pro/Examples & Extras/Resources/Fonts & Materials.meta
+++ b/BotRoyaleUnity/Assets/TextMesh Pro/Examples & Extras/Resources/Fonts & Materials.meta
@@ -1,8 +1,0 @@
-fileFormatVersion: 2
-guid: 4f1e85c79acf49968737939ce8b445c7
-folderAsset: yes
-DefaultImporter:
-  externalObjects: {}
-  userData: 
-  assetBundleName: 
-  assetBundleVariant: 

--- a/BotRoyaleUnity/Assets/TextMesh Pro/Examples & Extras/Resources/Sprite Assets.meta
+++ b/BotRoyaleUnity/Assets/TextMesh Pro/Examples & Extras/Resources/Sprite Assets.meta
@@ -1,8 +1,0 @@
-fileFormatVersion: 2
-guid: 3ac6db30e75b49b282a3564110579f27
-folderAsset: yes
-DefaultImporter:
-  externalObjects: {}
-  userData: 
-  assetBundleName: 
-  assetBundleVariant: 

--- a/BotRoyaleUnity/Assets/TextMesh Pro/Examples & Extras/Scenes.meta
+++ b/BotRoyaleUnity/Assets/TextMesh Pro/Examples & Extras/Scenes.meta
@@ -1,8 +1,0 @@
-fileFormatVersion: 2
-guid: db1090641b3241f6995b587eb21637bc
-folderAsset: yes
-DefaultImporter:
-  externalObjects: {}
-  userData: 
-  assetBundleName: 
-  assetBundleVariant: 

--- a/BotRoyaleUnity/Assets/TextMesh Pro/Examples & Extras/Scripts.meta
+++ b/BotRoyaleUnity/Assets/TextMesh Pro/Examples & Extras/Scripts.meta
@@ -1,8 +1,0 @@
-fileFormatVersion: 2
-guid: 3979ce59e55144c89a2b3b3f8dcf7fd3
-folderAsset: yes
-DefaultImporter:
-  externalObjects: {}
-  userData: 
-  assetBundleName: 
-  assetBundleVariant: 

--- a/BotRoyaleUnity/Assets/TextMesh Pro/Examples & Extras/Sprites.meta
+++ b/BotRoyaleUnity/Assets/TextMesh Pro/Examples & Extras/Sprites.meta
@@ -1,8 +1,0 @@
-fileFormatVersion: 2
-guid: 701e577af2ba48b689972d42efb95456
-folderAsset: yes
-DefaultImporter:
-  externalObjects: {}
-  userData: 
-  assetBundleName: 
-  assetBundleVariant: 

--- a/BotRoyaleUnity/Assets/TextMesh Pro/Examples & Extras/Textures.meta
+++ b/BotRoyaleUnity/Assets/TextMesh Pro/Examples & Extras/Textures.meta
@@ -1,8 +1,0 @@
-fileFormatVersion: 2
-guid: 6e5c6d5e25574122a7a12dbdbbeed156
-folderAsset: yes
-DefaultImporter:
-  externalObjects: {}
-  userData: 
-  assetBundleName: 
-  assetBundleVariant: 

--- a/BotRoyaleUnity/Assets/UnitySocketIO/WebSocketSharp/websocket-sharp.csproj.meta
+++ b/BotRoyaleUnity/Assets/UnitySocketIO/WebSocketSharp/websocket-sharp.csproj.meta
@@ -1,0 +1,7 @@
+fileFormatVersion: 2
+guid: a842b7b45f4bbfe4aa3778b250f98003
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 


### PR DESCRIPTION
Fixed some minor issues in the Unity project.
- Removed the TextMesh Pro examples meta files. The example files are not in the repo, but the meta files for them are. Removed these meta files.
- Added the meta file for the csproj file from the C# socket.io library. It was missing for some reason.
- Fixed compiler warnings for "private value never assigned to" fields that are serialized to be edited in the inspector.

Let me know if any of these changes causes any warnings or errors for you when you load or run the game on your computer